### PR TITLE
Add reminder to spell check to work report checklist

### DIFF
--- a/se-wkrpt/se-wtr-todo-list.html
+++ b/se-wkrpt/se-wtr-todo-list.html
@@ -99,6 +99,7 @@
     <li>Report length should be between 2000 and 3000 words long</li>
     <li>Your work report must describe a design decision (or a series of related smaller decisions) and justify a choice</li>
     <li>The report can be in an engineering format or a blog-style post</li>
+    <li>Work reports must be free of spelling mistakes. (Spell checkers exist; use them!)</li>
     <li>Reports are due 7 calendar days after the first day of lectures; late submissions will be given a failing grade and graded
         the following term</li>
 </ul>


### PR DESCRIPTION
If you're writing your report in a text editor, it's easy to forget to spell check. Having a reminder in the checklist will certainly help a lot of students. :)

The prose for this item is directly from the work report guidelines themselves.